### PR TITLE
Hide cvc on card

### DIFF
--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -13,6 +13,9 @@ const s = StyleSheet.create({
   baseInputStyle: {
     color: "black",
   },
+  containerAlignItems: {
+    alignItems: 'flex-start'
+  }
 });
 
 export default class CCInput extends Component {
@@ -74,7 +77,7 @@ export default class CCInput extends Component {
     return (
       <TouchableOpacity onPress={this.focus}
         activeOpacity={0.99}>
-        <View style={[containerStyle]}>
+        <View style={[containerStyle, s.containerAlignItems]}>
           { !!label && <Text style={[labelStyle]}>{label}</Text>}
           <TextInput ref="input"
             {...additionalInputProps}

--- a/src/CCInput.js
+++ b/src/CCInput.js
@@ -70,7 +70,7 @@ export default class CCInput extends Component {
     const { label, value, placeholder, status, keyboardType,
             containerStyle, inputStyle, labelStyle,
             validColor, invalidColor, placeholderColor,
-            additionalInputProps } = this.props;
+            additionalInputProps, secureTextEntry } = this.props;
     return (
       <TouchableOpacity onPress={this.focus}
         activeOpacity={0.99}>
@@ -81,6 +81,7 @@ export default class CCInput extends Component {
             keyboardType={keyboardType}
             autoCapitalise="words"
             autoCorrect={false}
+            secureTextEntry={secureTextEntry}
             style={[
               s.baseInputStyle,
               inputStyle,

--- a/src/CardView.js
+++ b/src/CardView.js
@@ -110,10 +110,12 @@ export default class CardView extends Component {
     imageBack: require("../images/card-back.png"),
   };
 
+  hideCVC = cvc => Array.from(cvc).map(char => '•').join('');
+
   render() {
     const { focused,
-      brand, name, number, expiry, cvc, customIcons,
-      placeholder, imageFront, imageBack, scale, fontFamily } = this.props;
+      brand, name, number, expiry, cvc, customIcons, placeholder,
+      imageFront, imageBack, scale, fontFamily, hideCVC } = this.props;
 
     const Icons = { ...defaultIcons, ...customIcons };
     const isAmex = brand === "american-express";
@@ -146,20 +148,20 @@ export default class CardView extends Component {
                 { !name ? placeholder.name : name.toUpperCase() }
               </Text>
               <Text style={[s.baseText, { fontFamily }, s.expiryLabel, s.placeholder, focused === "expiry" && s.focused]}>
-                {placeholder.expiryLabel}
+              {placeholder.expiryLabel}
               </Text>
               <Text style={[s.baseText, { fontFamily }, s.expiry, !expiry && s.placeholder, focused === "expiry" && s.focused]}>
                 { !expiry ? placeholder.expiry : expiry }
               </Text>
               { isAmex &&
                   <Text style={[s.baseText, { fontFamily }, s.amexCVC, !cvc && s.placeholder, focused === "cvc" && s.focused]}>
-                    { !cvc ? placeholder.cvc : cvc }
+                    { !cvc ? placeholder.cvc : ((hideCVC && this.hideCVC(cvc)) || cvc) }
                   </Text> }
           </ImageBackground>
           <ImageBackground style={[BASE_SIZE, s.cardFace, transform]}
             source={imageBack}>
               <Text style={[s.baseText, s.cvc, !cvc && s.placeholder, focused === "cvc" && s.focused]}>
-                { !cvc ? placeholder.cvc : cvc }
+                { !cvc ? placeholder.cvc : ((hideCVC && this.hideCVC(cvc)) || cvc) }
               </Text>
           </ImageBackground>
         </FlipCard>

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -168,7 +168,7 @@ export default class CreditCardInput extends Component {
       cardImageFront, cardImageBack, inputContainerStyle, containerStyle,
       values: { number, expiry, cvc, name, type }, focused,
       allowScroll, requiresName, requiresCVC, requiresPostalCode,
-      cardScale, cardFontFamily, cardBrandIcons, cardPlaceholders,
+      cardScale, cardFontFamily, cardBrandIcons, cardPlaceholders, hideCVC,
       cardNumberInputWidth, expiryInputWidth, cvcInputWidth, nameInputWidth,
       postalCodeInputWidth, renderInputButton
     } = this.props;
@@ -185,33 +185,36 @@ export default class CreditCardInput extends Component {
           number={number}
           expiry={expiry}
           cvc={cvc}
-          placeholder={cardPlaceholders} />
+          placeholder={cardPlaceholders}
+          hideCVC={hideCVC}
+        />
         <ScrollView ref="Form"
           keyboardShouldPersistTaps="always"
           scrollEnabled={allowScroll}
           showsHorizontalScrollIndicator={false}
           style={s.form}>
           <View style={s.cardNumberContainer}>
-            <CCInput {...this._inputProps("number")}
-              keyboardType="numeric"
-              containerStyle={[inputContainerStyle, { width: cardNumberInputWidth || CARD_NUMBER_INPUT_WIDTH }]}
+          <CCInput {...this._inputProps("number")}
+            keyboardType="numeric"
+            containerStyle={[inputContainerStyle, { width: cardNumberInputWidth || CARD_NUMBER_INPUT_WIDTH }]}
               />
             {renderInputButton()}
           </View>
           <View style={s.cvcDuedateContainer}>
-            <CCInput {...this._inputProps("expiry")}
+          <CCInput {...this._inputProps("expiry")}
+            keyboardType="numeric"
+            containerStyle={[inputContainerStyle, { width: expiryInputWidth || EXPIRY_INPUT_WIDTH }]} />
+          { requiresCVC &&
+            <CCInput {...this._inputProps("cvc")}
               keyboardType="numeric"
-              containerStyle={[inputContainerStyle, { width: expiryInputWidth || EXPIRY_INPUT_WIDTH }]} />
-            { requiresCVC &&
-              <CCInput {...this._inputProps("cvc")}
-                keyboardType="numeric"
-                containerStyle={[inputContainerStyle, { width: cvcInputWidth || CVC_INPUT_WIDTH }]} /> }
-          </View>      
-          <View style={s.cardHolderNameContainer}>              
-            { requiresName &&
-              <CCInput {...this._inputProps("name")}
-                containerStyle={[inputContainerStyle, { width: nameInputWidth || NAME_INPUT_WIDTH }]} /> }
-          </View>
+              containerStyle={[inputContainerStyle, { width: cvcInputWidth || CVC_INPUT_WIDTH }]}
+              secureTextEntry={hideCVC} /> }
+               </View>      
+          <View style={s.cardHolderNameContainer}>
+          { requiresName &&
+            <CCInput {...this._inputProps("name")}
+            containerStyle={[inputContainerStyle, { width: nameInputWidth || NAME_INPUT_WIDTH }]} /> }
+            </View>
           { requiresPostalCode &&
             <CCInput {...this._inputProps("postalCode")}
               keyboardType="numeric"

--- a/src/CreditCardInput.js
+++ b/src/CreditCardInput.js
@@ -170,8 +170,10 @@ export default class CreditCardInput extends Component {
       allowScroll, requiresName, requiresCVC, requiresPostalCode,
       cardScale, cardFontFamily, cardBrandIcons, cardPlaceholders, hideCVC,
       cardNumberInputWidth, expiryInputWidth, cvcInputWidth, nameInputWidth,
-      postalCodeInputWidth, renderInputButton
+      postalCodeInputWidth, renderInputButton, verticalFields
     } = this.props;
+    
+    if(verticalFields){
     return (
       <View style={[s.container, containerStyle]}>
         <CreditCard focused={focused}
@@ -222,5 +224,48 @@ export default class CreditCardInput extends Component {
         </ScrollView>
       </View>
     );
+    }
+      return (
+        <View style={[s.container, containerStyle]}>
+          <CreditCard focused={focused}
+            brand={type}
+            scale={cardScale}
+            fontFamily={cardFontFamily}
+            imageFront={cardImageFront}
+            imageBack={cardImageBack}
+            customIcons={cardBrandIcons}
+            name={requiresName ? name : " "}
+            number={number}
+            expiry={expiry}
+            cvc={cvc}
+            placeholder={cardPlaceholders}
+            hideCVC={hideCVC} />
+          <ScrollView ref="Form"
+            horizontal
+            keyboardShouldPersistTaps="always"
+            scrollEnabled={allowScroll}
+            showsHorizontalScrollIndicator={false}
+            style={s.form}>
+            <CCInput {...this._inputProps("number")}
+              keyboardType="numeric"
+              containerStyle={[s.inputContainer, inputContainerStyle, { width: cardNumberInputWidth || CARD_NUMBER_INPUT_WIDTH }]} />
+            <CCInput {...this._inputProps("expiry")}
+              keyboardType="numeric"
+              containerStyle={[s.inputContainer, inputContainerStyle, { width: expiryInputWidth || EXPIRY_INPUT_WIDTH }]} />
+            { requiresCVC &&
+              <CCInput {...this._inputProps("cvc")}
+                keyboardType="numeric"
+                containerStyle={[s.inputContainer, inputContainerStyle, { width: cvcInputWidth || CVC_INPUT_WIDTH }]}
+                secureTextEntry={hideCVC} /> }
+            { requiresName &&
+              <CCInput {...this._inputProps("name")}
+              containerStyle={[s.inputContainer, inputContainerStyle, { width: nameInputWidth || NAME_INPUT_WIDTH }]} /> }
+            { requiresPostalCode &&
+              <CCInput {...this._inputProps("postalCode")}
+                keyboardType="numeric"
+                containerStyle={[s.inputContainer, inputContainerStyle, { width: postalCodeInputWidth || POSTAL_CODE_INPUT_WIDTH }]} /> }
+          </ScrollView>
+        </View>
+      );
   }
 }


### PR DESCRIPTION
## Summary

- You can hide the CVC using a prop called 'hideCVC' (CVC is shown by default).
- Changed fields layout to see them vertically or horizontally using a prop called 'verticalFields' (horizontal fields are shown by default).
- Changed text alignment to show fields properly.

## Screenshots with Test Cases

Hidden CVC on EDES using horizontal fields:

![edes1](https://user-images.githubusercontent.com/51789658/64050946-eb2d9a00-cb4f-11e9-9a87-6e7632ac98dc.png)

Show CVC on EDES using vertical fields:

![edes2](https://user-images.githubusercontent.com/51789658/64050955-f2ed3e80-cb4f-11e9-88b3-ef92cf0a63e2.png)

Hide CVC using AMEX card:

![Amex](https://user-images.githubusercontent.com/51789658/64050968-fb457980-cb4f-11e9-850a-3eef0aa687ac.png)

## JIRA Issue
https://widergy.atlassian.net/browse/OPS-274