### PR TITLE
[OPC-2173]Missing cc patterns fix

### DIFF
--- a/src/CCFieldValidator.js
+++ b/src/CCFieldValidator.js
@@ -2,22 +2,11 @@ import valid from "card-validator";
 import pick from "lodash.pick";
 import values from "lodash.values";
 import every from "lodash.every";
-import { CARDS_OVERRIDES } from "./cardsOverrides";
+import { CARDS_OVERRIDES, VALID, INCOMPLETE } from "./constants";
+import { toStatus, maestroCardStatus } from "./utils";
 
-const MAESTR0_BASE_LENGTH = 12;
+
 CARDS_OVERRIDES.forEach(card => valid.creditCardType.addCard(card));
-
-const toStatus = validation => {
-  return validation.isValid ? "valid" :
-         validation.isPotentiallyValid ? "incomplete" :
-         "invalid";
-};
-
-const hasProperLength = cardNumber => cardNumber.split(" ").join("").length >= MAESTR0_BASE_LENGTH;
-const maestroCardStatus = (numberValidation, cardNumber) =>
-  hasProperLength(cardNumber)
-  && numberValidation.card
-  && numberValidation.card.type === "maestro" && "valid";
 
 const FALLBACK_CARD = { gaps: [4, 8, 12], lengths: [16], code: { size: 3 } };
 export default class CCFieldValidator {
@@ -36,12 +25,12 @@ export default class CCFieldValidator {
       number: maestroCardStatus(numberValidation, formValues.number) || toStatus(numberValidation),
       expiry: toStatus(expiryValidation),
       cvc: toStatus(cvcValidation),
-      name: !!formValues.name ? "valid" : "incomplete",
+      name: !!formValues.name ? VALID : INCOMPLETE,
       postalCode: this._validatePostalCode(formValues.postalCode),
     }, this._displayedFields);
 
     return {
-      valid: every(values(validationStatuses), status => status === "valid"),
+      valid: every(values(validationStatuses), status => status === VALID),
       status: validationStatuses,
     };
   };

--- a/src/CCFieldValidator.js
+++ b/src/CCFieldValidator.js
@@ -2,12 +2,22 @@ import valid from "card-validator";
 import pick from "lodash.pick";
 import values from "lodash.values";
 import every from "lodash.every";
+import { CARDS_OVERRIDES } from "./cardsOverrides";
+
+const MAESTR0_BASE_LENGTH = 12;
+CARDS_OVERRIDES.forEach(card => valid.creditCardType.addCard(card));
 
 const toStatus = validation => {
   return validation.isValid ? "valid" :
          validation.isPotentiallyValid ? "incomplete" :
          "invalid";
 };
+
+const hasProperLength = cardNumber => cardNumber.split(" ").join("").length >= MAESTR0_BASE_LENGTH;
+const maestroCardStatus = (numberValidation, cardNumber) =>
+  hasProperLength(cardNumber)
+  && numberValidation.card
+  && numberValidation.card.type === "maestro" && "valid";
 
 const FALLBACK_CARD = { gaps: [4, 8, 12], lengths: [16], code: { size: 3 } };
 export default class CCFieldValidator {
@@ -23,7 +33,7 @@ export default class CCFieldValidator {
     const cvcValidation = valid.cvv(formValues.cvc, maxCVCLength);
 
     const validationStatuses = pick({
-      number: toStatus(numberValidation),
+      number: maestroCardStatus(numberValidation, formValues.number) || toStatus(numberValidation),
       expiry: toStatus(expiryValidation),
       cvc: toStatus(cvcValidation),
       name: !!formValues.name ? "valid" : "incomplete",

--- a/src/cardsOverrides.js
+++ b/src/cardsOverrides.js
@@ -1,0 +1,71 @@
+/* eslint-disable comma-dangle */
+const MAESTRO_CARD_TYPE = {
+  niceType: "Maestro",
+  type: "maestro",
+  patterns: [
+    493698,
+    [500000, 506698],
+    [506779, 508999],
+    [56, 59],
+    63,
+    67,
+    6,
+    601782,
+    508143,
+    501081,
+    501080,
+    501051,
+    501059,
+    557909,
+    501066,
+    588729,
+    501075,
+    501062,
+    501060,
+    501057,
+    501056,
+    501055,
+    501053,
+    501043,
+    501041,
+    501038,
+    501028,
+    501023,
+    501021,
+    501020,
+    501018,
+    501016
+  ],
+  gaps: [4, 8, 12],
+  lengths: [12, 13, 14, 15, 16, 17, 18, 19],
+  code: {
+    name: "CVC",
+    size: 3
+  }
+};
+
+const VISA_CARD_TYPE = {
+  niceType: "Visa",
+  type: "visa",
+  patterns: [4, 4026, 417500, 4405, 4508, 4844, 4913, 4917],
+  gaps: [4, 8, 12],
+  lengths: [16, 18, 19],
+  code: {
+    name: "CVV",
+    size: 3
+  }
+};
+
+const HIPER_CARD_TYPE = {
+  niceType: "Hipercard",
+  type: "hipercard",
+  patterns: [606282, 637599, 637609, 637612, 384100, 384140, 384160, 606282, 637095, 637568],
+  gaps: [4, 8, 12],
+  lengths: [16],
+  code: {
+    name: "CVC",
+    size: 3
+  }
+};
+
+export const CARDS_OVERRIDES = [MAESTRO_CARD_TYPE, VISA_CARD_TYPE, HIPER_CARD_TYPE];

--- a/src/constants.js
+++ b/src/constants.js
@@ -69,3 +69,9 @@ const HIPER_CARD_TYPE = {
 };
 
 export const CARDS_OVERRIDES = [MAESTRO_CARD_TYPE, VISA_CARD_TYPE, HIPER_CARD_TYPE];
+
+export const MAESTRO = "maestro";
+export const VALID = "valid";
+export const INCOMPLETE = "incomplete";
+export const INVALID = "invalid";
+export const MAESTR0_BASE_LENGTH = 12;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,15 @@
+import { VALID, INCOMPLETE, INVALID, MAESTRO, MAESTR0_BASE_LENGTH } from "./constants";
+
+export const toStatus = validation => {
+  return validation.isValid ? VALID :
+         validation.isPotentiallyValid ? INCOMPLETE :
+         INVALID;
+};
+
+export const hasProperLength = (cardNumber, length) => cardNumber.split(" ").join("").length >= length;
+export const cardStatus = (numberValidation, cardNumber, cardType, cardBaseLength) =>
+  hasProperLength(cardNumber, cardBaseLength)
+  && numberValidation.card
+  && numberValidation.card.type === cardType && VALID;
+
+export const maestroCardStatus = (numberValidation, cardNumber) => cardStatus(numberValidation, cardNumber, MAESTRO, MAESTR0_BASE_LENGTH);


### PR DESCRIPTION
## Summary

Changes:

- Added new patterns for some of the card issuers, in order to recognize them whenever the user enters a card number. I added several new patterns for visa, Maestro and Hipercard, these are the same that are currently in use in the web-utils.
By doing so, the validator functions included in the `credit-card-type` library (it's a dependency) checks for partial/complete matches and returns the card issuer and it's validity.

- Added a escape hatch for maestro cards. For certain maestro cards numbers, the checksum algorithm traditionally used to check for the numbers validity was failing. To allow for these numbers to be entered in the payment form, I added a escape hatch similar to the one used in web-utils.

By the way, I'm checking for a minimum length of 12 digits before assuming a maestro card to be valid, for two reasons:
a) since we currently depend on the `credit-card-validator` dependency to determine the validity of the user's input, by checking for the length we make sure that the user enters at least the minimum amounts of digits required for a maestro card (due to the escape hatch logic).
b) To avoid a premature scroll to the next field in the form. Whenever a field input is valid, the form scrolls and focuses the next one. This is kind of a patch so we don't have to disable this behaviour for a specific card issuer, or even disable it completely.

## Test Cases

To test this, check for these cards to match in the payment form. An easy way to check for this is adding a `console.log(numberValidation)` in the CCValidator class. This will show an object holding data regarding the user input. 
The object will contain data regarding the identified card (if there's any) including the patterns used to try to match and the issuer, its potential validity and its 'absolute validity'.
If it's potentially valid, it means that it 'could be' a card of a certain issuer. If it appears as 'valid', it means that it made for the strongest match amongst the patterns used to check.

- 5010519925883132 this is the maestro card that was causing the mentioned issue with the card validity algorithm, it should match as a maestro card. Bear in mind that the icon of the maestro card won't appear on the top right side of the animated card, since it's not included in the library.
- 4509 9535 6623 3704 valid visa testing card
- 5031 7557 3453 0604 valid mastercard testing card
- 3711 803032 57522 valid AMEX testing card

Any other number you can came up with to test for invalid cards. Bear in mind, a random credit card number with anywhere between 12 and 22 can match as a valid card number.

## Screenshots

![Screenshot_1585775755](https://user-images.githubusercontent.com/46002563/78254185-e9ec9300-74cb-11ea-910d-29f4df3881c7.png)

![Screenshot_1585775728](https://user-images.githubusercontent.com/46002563/78254192-ec4eed00-74cb-11ea-9eb4-3689f31801fd.png)

## JIRA Issue
[OPC-2173](https://widergy.atlassian.net/browse/OPC-2173)
