### PR TITLE
Added cabal cards

### DIFF
--- a/src/CCFieldValidator.js
+++ b/src/CCFieldValidator.js
@@ -2,12 +2,11 @@ import valid from "card-validator";
 import pick from "lodash.pick";
 import values from "lodash.values";
 import every from "lodash.every";
-import { CARDS_OVERRIDES, VALID, INCOMPLETE, CABAL_CARD_TYPE } from "./constants";
+import { CARDS_OVERRIDES, VALID, INCOMPLETE } from "./constants";
 import { toStatus, maestroCardStatus } from "./utils";
 
 
 CARDS_OVERRIDES.forEach(card => valid.creditCardType.addCard(card));
-valid.creditCardType.addCard(CABAL_CARD_TYPE);
 
 const FALLBACK_CARD = { gaps: [4, 8, 12], lengths: [16], code: { size: 3 } };
 export default class CCFieldValidator {

--- a/src/CCFieldValidator.js
+++ b/src/CCFieldValidator.js
@@ -2,11 +2,12 @@ import valid from "card-validator";
 import pick from "lodash.pick";
 import values from "lodash.values";
 import every from "lodash.every";
-import { CARDS_OVERRIDES, VALID, INCOMPLETE } from "./constants";
+import { CARDS_OVERRIDES, VALID, INCOMPLETE, CABAL_CARD_TYPE } from "./constants";
 import { toStatus, maestroCardStatus } from "./utils";
 
 
 CARDS_OVERRIDES.forEach(card => valid.creditCardType.addCard(card));
+valid.creditCardType.addCard(CABAL_CARD_TYPE);
 
 const FALLBACK_CARD = { gaps: [4, 8, 12], lengths: [16], code: { size: 3 } };
 export default class CCFieldValidator {

--- a/src/constants.js
+++ b/src/constants.js
@@ -68,6 +68,18 @@ const HIPER_CARD_TYPE = {
   }
 };
 
+export const CABAL_CARD_TYPE = {
+  niceType: "Cabal",
+  type: "cabal",
+  patterns: [627170, 589657, 603522, [604201, 604209], [210, 299], 302, 312, 322, 332, 342, 352, 362, 372, 382, 392, 400],
+  gaps: [4, 8, 12],
+  lengths: [16],
+  code: {
+    name: "CVC",
+    size: 3
+  }
+};
+
 export const CARDS_OVERRIDES = [MAESTRO_CARD_TYPE, VISA_CARD_TYPE, HIPER_CARD_TYPE];
 
 export const MAESTRO = "maestro";

--- a/src/constants.js
+++ b/src/constants.js
@@ -68,7 +68,7 @@ const HIPER_CARD_TYPE = {
   }
 };
 
-export const CABAL_CARD_TYPE = {
+const CABAL_CARD_TYPE = {
   niceType: "Cabal",
   type: "cabal",
   patterns: [627170, 589657, 603522, [604201, 604209], [210, 299], 302, 312, 322, 332, 342, 352, 362, 372, 382, 392, 400],
@@ -80,7 +80,7 @@ export const CABAL_CARD_TYPE = {
   }
 };
 
-export const CARDS_OVERRIDES = [MAESTRO_CARD_TYPE, VISA_CARD_TYPE, HIPER_CARD_TYPE];
+export const CARDS_OVERRIDES = [MAESTRO_CARD_TYPE, VISA_CARD_TYPE, HIPER_CARD_TYPE, CABAL_CARD_TYPE];
 
 export const MAESTRO = "maestro";
 export const VALID = "valid";


### PR DESCRIPTION
## Summary

Added cabal credit card type to the supported cards list.

## Test Cases

To test this, I suggest using the edesa project. Simply run this: `yarn add https://github.com/widergy/react-native-credit-card-input\#add-cabal-cards`. This will make the package.json dependency point to this particular branch.

Then, test these patterns belonging to cabal credit cards. The type shown on the payload within an onChange redux form event should state 'cabal'.

627170
589657
603522
and this full card number to get a valid match: 6042015456770036

I also tested with a variety of other card numbers from another issuers (amex, visa, maestro), and they work just fine. Feel free to test with any other card number you come up with.

## Screenshots

![cabal_card_1](https://user-images.githubusercontent.com/46002563/78596129-9c508d00-7821-11ea-86e9-59f0f2c07f16.png)

## JIRA Issue
[OPC-2283](https://widergy.atlassian.net/browse/OPC-2283)
[OPC-2284](https://widergy.atlassian.net/browse/OPC-2284)
